### PR TITLE
acccounttest-DarkChrome-AHKItemDeleter-file-only

### DIFF
--- a/Mandatory/deleteElementButGetNotMenuRandom.AHK
+++ b/Mandatory/deleteElementButGetNotMenuRandom.AHK
@@ -70,7 +70,7 @@ SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
     Send, {LButton up}
     Sleep, 10
     Send, {AppsKey}
-    Sleep, 100
+    Sleep, 250
     Send, {Up}
     Sleep, 10
     Send, {Up}
@@ -84,6 +84,6 @@ SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
     Send, {Enter}
     Sleep, 10
     MouseMove, %savex%,%savey%
-    return   
-
+    return
+; dont hesit to add or remove rela numbers needed, but it's better to keep higher timings and intercept the menu with same keys in case of troubles.
 }


### PR DESCRIPTION
acccounttest-DarkChrome-AHKItemDeleter_Timing_sleeps_mix_the_up_keys_send_then_wrong_menu_entries_then_subs
The timing of the sleep and the menus act not like all element under the mouse, this result into a wrong menu selected, the keys up send are like a wrong number, so we select the wrong item, next you can maybe navigate further because you are on a sub menu so the sub menu allow the main menu accessible.

Please use the readme of the title of the previous branch commit.
This time, the menu act differently depending on type of element under the mouse pointer but more the layers, div and extra popups.
If you try modify the timings, the behaviour is different, it's like you need to take much or less time to realize the same operations, or even, doing someting else like:
-Open "chrome dev tools" like ctrl+shift+j do and miss the menu and the choices.
-Stay in another sub menu that can only react to the left, right and enter.

If you think this can lead to compromises, try to keep only sub menus entries at first level of the main menu, or regroup them at least by the end, please try to intercept any wrong usages by the directional keys or equivalent.